### PR TITLE
SEO: Fix meta descriptions for key pages

### DIFF
--- a/aboutme.md
+++ b/aboutme.md
@@ -1,8 +1,9 @@
 ---
 layout: page
-title: About me
+title: "About Will Cooke (8none1)"
 subtitle: Hello chief let's talk, why not.
 cover-img: "/assets/img/flask.png"
+share-description: "About Will Cooke (8none1) - Software engineer at Chainguard, former Ubuntu Desktop Director at Canonical, Late Night Linux podcast co-host."
 ---
 
 I'm **Will Cooke**. See my [identity page](/will-cooke/) for a quick overview and links to find me elsewhere.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: home
 title: "Will Cooke (8none1)"
 subtitle: "Software engineer, podcaster, Linux enthusiast"
+share-description: "Will Cooke (8none1) - Personal blog about software engineering, Linux, home automation, and gadgets. Manager at Chainguard, Late Night Linux podcast co-host."
 ---
 
 <p>Welcome to <strong>whizzy.org</strong>, the personal site of <strong>Will Cooke</strong> (aka <strong>8none1</strong>).</p>

--- a/will-cooke.md
+++ b/will-cooke.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Will Cooke (8none1)"
 permalink: /will-cooke/
-description: "Will Cooke (8none1) - Software engineer, podcaster, and Linux enthusiast. This is the official identity page for Will Cooke."
+share-description: "Will Cooke (8none1) - Software engineer, podcaster, and Linux enthusiast. Manager at Chainguard, Late Night Linux co-host, former Ubuntu Desktop Director."
 ---
 
 # Will Cooke


### PR DESCRIPTION
## Summary

Fixes meta description issues identified in the SEO audit. Beautiful Jekyll uses `share-description` for meta tags, not `description`.

## Changes

| File | Before | After |
|------|--------|-------|
| `will-cooke.md` | Raw markdown in meta description | Proper `share-description` field |
| `index.html` | 47 char description (too short) | 156 char keyword-rich description |
| `aboutme.md` | Title: "About me", no description | Title: "About Will Cooke (8none1)" + description |

## Expected Results

**Homepage meta description:**
```
Will Cooke (8none1) - Personal blog about software engineering, Linux, home automation, and gadgets. Manager at Chainguard, Late Night Linux podcast co-host.
```

**Will Cooke page meta description:**
```
Will Cooke (8none1) - Software engineer, podcaster, and Linux enthusiast. Manager at Chainguard, Late Night Linux co-host, former Ubuntu Desktop Director.
```

**About page:**
- Title: "About Will Cooke (8none1)"
- Description: "About Will Cooke (8none1) - Software engineer at Chainguard, former Ubuntu Desktop Director at Canonical, Late Night Linux podcast co-host."

## Test plan

- [ ] Build site and verify meta descriptions render correctly
- [ ] Check homepage `<meta name="description">` is ~150 chars
- [ ] Check /will-cooke/ page has clean description (no markdown)
- [ ] Check /aboutme/ title includes name

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)