### PR TITLE
Guard against pushing to upstream theme repo

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Refuse to push to the upstream Beautiful Jekyll theme repo.
+#
+# This site is a fork of daattali/beautiful-jekyll. Pushes (and the PRs that
+# can follow) must only ever go to our own fork, 8none1/8none1.github.io.
+# Git passes the remote name as $1 and its URL as $2.
+#
+# To enable this hook, run (once):
+#   git config core.hooksPath .githooks
+
+remote_name="$1"
+remote_url="$2"
+
+if printf '%s %s' "$remote_name" "$remote_url" | grep -qiE 'daattali/beautiful-jekyll'; then
+  echo "✋ Blocked: refusing to push to the upstream theme repo (daattali/beautiful-jekyll)." >&2
+  echo "   Push to your own fork instead:  git push origin <branch>" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Prevents a repeat of accidentally opening a PR / pushing against `daattali/beautiful-jekyll` (this site is a fork of that theme).

Three layers of protection — two are local git/gh config (applied directly, not in this diff), one is this committed hook:

1. **`gh repo set-default 8none1/8none1.github.io`** — `gh pr create` now always targets this fork as the base, instead of defaulting to the fork parent. *(local config)*
2. **`git remote set-url --push upstream DISABLE`** — `git push upstream` now fails fast. *(local config)*
3. **`.githooks/pre-push`** (this PR) — refuses any push whose remote resolves to `daattali/beautiful-jekyll`, regardless of remote name. Enable with `git config core.hooksPath .githooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)