### PR TITLE
Profile page: ProfilePage schema + consolidate /aboutme/ into /will-cooke/

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ description: >- # this means to ignore newlines until "baseurl:"
   Will Cooke - Software engineer, podcaster, and Linux enthusiast. Currently at Chainguard, Late Night Linux podcast co-host. Writing about code, gadgets, and home automation.
 
 navbar-links:
-   About Me: "aboutme"
    Will Cooke: "will-cooke"
 #   Resources:
 #     - Beautiful Jekyll: "https://beautifuljekyll.com"
@@ -118,6 +117,7 @@ plugins:
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-remote-theme
+  - jekyll-redirect-from
 
 
 exclude:

--- a/aboutme.md
+++ b/aboutme.md
@@ -1,33 +1,9 @@
 ---
 layout: page
 title: "About Will Cooke (8none1)"
-subtitle: Hello chief let's talk, why not.
-cover-img: "/assets/img/flask.png"
-share-description: "About Will Cooke (8none1) - Software engineer at Chainguard, former Ubuntu Desktop Director at Canonical, Late Night Linux podcast co-host."
+permalink: /aboutme/
+redirect_to: /will-cooke/
+sitemap: false
 ---
 
-I'm **Will Cooke**. See my [identity page](/will-cooke/) for a quick overview and links to find me elsewhere.
-
-I like computers.
-
-I work at [Chainguard](https://www.chainguard.dev/) on the OS team.  [We're hiring](https://www.chainguard.dev/careers), join us.
-
-I used to work at [InfluxData](https://www.influxdata.com) as the director of engineering for the storage engine and write-path.
-
-I used to work at [Canonical](https://www.canonical.com) as the director of Ubuntu Desktop.  I still use Ubuntu all day every day.
-
-I'm part of the [Late Night Linux](https://latenightlinux.com) podcast team.  We put out a weekly podcast about Linux, free software and general hatred of the Tory party.
-
-My amateur radio callsign is M7WZY.
-
-I'm on [Fosstodon](https://fosstodon.org/@8none1).
-
-I'm on [Twitter](https://twitter.com/8none1).
-
-I'm on [GitHub](https://github.com/8none1).
-
-I'm on [LinkedIn](https://www.linkedin.com/in/will-cooke-64b69417/).
-
-I'm on [Telegram](https://t.me/willcooke).
-
-I also like home automation, Internet connected things, plumbing, electrics and electronics, flying, craft beer, chicken wings and looking at graphs.
+I'm **Will Cooke**. My full profile has moved to [whizzy.org/will-cooke](/will-cooke/).

--- a/will-cooke.md
+++ b/will-cooke.md
@@ -23,15 +23,19 @@ I'm **Will Cooke** (aka **8none1**), a software engineer, engineering manager an
 
 ## What I work on
 
-- **Chainguard** - Manager the OS team, working on secure container images and supply chain security
+- **Chainguard** - Manager of the OS team, working on secure container images and supply chain security
 - **Late Night Linux** - Co-host of the weekly podcast about Linux and free software
 - **Open Source** - Long-time contributor and advocate; former Director of Ubuntu Desktop at Canonical
 - **Home Automation** - Building and tinkering with IoT devices and smart home systems
 - **Amateur Radio** - Callsign M7WZY
 
-## More about me
+## Career
 
-For more details about my background and interests, see the [About Me](/aboutme/) page.
+I work at [Chainguard](https://www.chainguard.dev/) on the OS team ([we're hiring](https://www.chainguard.dev/careers)). Before that I was Director of Engineering for the storage engine and write-path at [InfluxData](https://www.influxdata.com), and Director of Ubuntu Desktop at [Canonical](https://www.canonical.com) — I still use Ubuntu all day, every day.
+
+## Interests
+
+As well as Linux and open source, I like home automation, Internet-connected things, plumbing, electrics and electronics, flying, craft beer, chicken wings, and looking at graphs.
 
 <script type="application/ld+json">
 {

--- a/will-cooke.md
+++ b/will-cooke.md
@@ -32,3 +32,16 @@ I'm **Will Cooke** (aka **8none1**), a software engineer, engineering manager an
 ## More about me
 
 For more details about my background and interests, see the [About Me](/aboutme/) page.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  "@id": "https://www.whizzy.org/will-cooke/#profilepage",
+  "url": "https://www.whizzy.org/will-cooke/",
+  "name": "Will Cooke (8none1)",
+  "mainEntity": { "@id": "https://www.whizzy.org/will-cooke/#person" },
+  "about": { "@id": "https://www.whizzy.org/will-cooke/#person" },
+  "isPartOf": { "@id": "https://www.whizzy.org/#website" }
+}
+</script>


### PR DESCRIPTION
Makes `/will-cooke/` the single canonical profile page for the Will Cooke entity.

- **ProfilePage schema** on `/will-cooke/` with `mainEntity` → the existing `#person` node.
- **Enriched** `/will-cooke/` with the unique bio details from `/aboutme/` (InfluxData + Canonical history, interests).
- **Redirect** `/aboutme/` → `/will-cooke/` via `jekyll-redirect-from` (canonical + meta refresh), removed from sitemap, so two overlapping bio pages no longer split entity signals.
- **Nav** consolidated to a single `Will Cooke` link.

Build-validated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)